### PR TITLE
removed macos and python 3.7 testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        os: ["ubuntu-latest", "windows-latest"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
 
     steps:


### PR DESCRIPTION
They were breaking and not really needed, since Ubuntu should cover macos testing cases and [Python 3.7 has reached EoL a while ago](https://devguide.python.org/versions/)